### PR TITLE
Fix paths to bower_components and spec grunt alias

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-components/*
+bower_components/*
 node_modules/*

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,7 +21,7 @@ module.exports = function(grunt) {
         src : 'underscore-partials.js',
         options: {
           specs: 'specs/specs.js',
-          vendor: 'components/underscore/underscore.js'
+          vendor: 'bower_components/underscore/underscore.js'
         }
       }
     }
@@ -34,6 +34,6 @@ module.exports = function(grunt) {
 
   // Default task.
   grunt.registerTask('default', 'jshint');
-  grunt.registerTask('spec', 'jasmine-server');
+  grunt.registerTask('spec', 'jasmine');
   grunt.registerTask('build', ['jshint', 'clean', 'uglify']);
 };

--- a/specs/index.html
+++ b/specs/index.html
@@ -1,15 +1,15 @@
 <html>
 <head>
     <title>Tests for underscore-partials</title>
-    <script type="text/javascript" src="../components/jasmine/lib/jasmine-core/jasmine.js"></script>
-    <script type="text/javascript" src="../components/jasmine/lib/jasmine-core/jasmine-html.js"></script>
-    <script type="text/javascript" src="../components/underscore/underscore.js"></script>
+    <script type="text/javascript" src="../bower_components/jasmine/lib/jasmine-core/jasmine.js"></script>
+    <script type="text/javascript" src="../bower_components/jasmine/lib/jasmine-core/jasmine-html.js"></script>
+    <script type="text/javascript" src="../bower_components/underscore/underscore.js"></script>
 
     <script type="text/javascript" src="../underscore-partials.js"></script>
 
     <script type="text/javascript" src="specs.js"></script>
 
-    <link rel="stylesheet" href="../components/jasmine/lib/jasmine-core/jasmine.css"/>
+    <link rel="stylesheet" href="../bower_components/jasmine/lib/jasmine-core/jasmine.css"/>
 </head>
 <body>
 


### PR DESCRIPTION
- Fix all paths in project for bower components (`components` -> `bower_components`)
- Grunt task `spec` should run `jasmine` task instead of non-exsting `jasmine-server` task
