### PR TITLE
Allow templateSettings upon partial declaration

### DIFF
--- a/build/underscore-partials.min.js
+++ b/build/underscore-partials.min.js
@@ -1,1 +1,1 @@
-(function(){_.mixin(function(){var n={},t={partial:function(t,e){return n[t](e)}};return t.partial.declare=function(t,e){n[t]=_.template(e)},t.partial.exists=function(t){return!_.isUndefined(n[t])},t.partial.remove=function(t){delete n[t]},t}())})();
+(function(){_.mixin(function(){var n={},t={partial:function(t,i){return n[t](i)}};return t.partial.declare=function(t,i,e){n[t]=_.template(i,void 0,e)},t.partial.exists=function(t){return!_.isUndefined(n[t])},t.partial.remove=function(t){delete n[t]},t}())})();

--- a/specs/specs.js
+++ b/specs/specs.js
@@ -46,6 +46,48 @@ describe("Underscore partials", function() {
 
         expect(template()).toBe("User rating: 4 stars (****)");
     });
+
+    describe("with template setting", function() {
+        beforeEach(function() {
+            templateSettings1 = {
+              interpolate: /<\@\=([\s\S]+?)\@\>/gim,
+              evaluate: /<\@([\s\S]+?)\@\>/gim
+            };
+            templateSettings2 = {
+              interpolate: /<\#\=([\s\S]+?)\#\>/gim,
+              evaluate: /<\@([\s\S]+?)\@\>/gim
+            };
+        });
+
+        it("can declare a new partial", function() {
+            var partial = "hello";
+            _.partial.declare("hello", partial, templateSettings1);
+            expect(_.partial("hello")).toBe("hello");
+        });
+
+        it("can overwrite an existing partial", function() {
+            var partial1 = "hello1 <@= name @>!";
+            var partial2 = "hello2 <#= name #>!";
+            _.partial.declare("hello", partial1, templateSettings1);
+            _.partial.declare("hello", partial2, templateSettings2);
+            expect(_.partial("hello", {name: "bob"})).toBe("hello2 bob!");
+        });
+
+        it("gives you the full power of Underscore templates in a partial", function(){
+            var partial = "Hello <@= name @>";
+            _.partial.declare("hello", partial, templateSettings1);
+            expect(_.partial("hello", {name: "bob"})).toBe("Hello bob");
+        });
+
+        it("let's you use a partial inside of a template", function(){
+            var partial = "<@= rating @> stars (<@ for(var i = 0; i < rating; i++) { @>*<@ } @>)";
+            var template = "User rating: <#= _.partial('star_rating', {rating: 4}) #>";
+            _.partial.declare('star_rating', partial, templateSettings1);
+            template = _.template(template, undefined, templateSettings2);
+
+            expect(template()).toBe("User rating: 4 stars (****)");
+        });
+    });
 });
 
 (function() {

--- a/underscore-partials.js
+++ b/underscore-partials.js
@@ -12,8 +12,8 @@
             }
         };
 
-        mixin.partial.declare = function(name, template) {
-            partialCache[name] = _.template(template);
+        mixin.partial.declare = function(name, template, templateSettings) {
+            partialCache[name] = _.template(template, undefined, templateSettings);
         };
 
         mixin.partial.exists = function(name) {


### PR DESCRIPTION
Enable template settings for partials.

Each partial can have its own individual template settings even when rendering a partial within a template with completely different template settings.
