### PR TITLE
Grunt `test` task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -34,6 +34,6 @@ module.exports = function(grunt) {
 
   // Default task.
   grunt.registerTask('default', 'jshint');
-  grunt.registerTask('spec', 'jasmine');
+  grunt.registerTask('test', 'jasmine');
   grunt.registerTask('build', ['jshint', 'clean', 'uglify']);
 };

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ _.partial.remove('partial_name');
 
 ## Run the test suite
 
-    grunt jasmine
+    grunt test
 
 # Licence
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "grunt-contrib-uglify": "^0.1.2"
   },
   "scripts": {
-    "test": "grunt jasmine"
+    "test": "grunt test"
   },
   "repository": "",
   "author": "",


### PR DESCRIPTION
Abstracted the testing task under the name (alias to be more precise) `test`, no matter the testing library used. Usage: `npm test` and `grunt test`.
