### PR TITLE
Move partials functionality to _.template.partial (closes #5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ Example:
 
 <!-- main.tmpl -->
 <h1><%= product.name %></h1>
-<div><%= _.partial('star_rating', {rating: product.rating}) %></div>
+<div><%= _.template.partial('star_rating', {rating: product.rating}) %></div>
 ```
 
 ```javascript
 var template = _.template(main.tmpl);
-_.partial.declare('star_rating', star_rating.tmpl);
+_.template.partial.declare('star_rating', star_rating.tmpl);
 template({product: {name: "DVD Player", rating: 3}});
 ```
 
@@ -34,18 +34,18 @@ Will output
 
 ```javascript
 // Declare a partial
-_.partial.declare('partial_name', partialString);
+_.template.partial.declare('partial_name', partialString);
 
 // Use a partial
-_.partial('partial_name');
+_.template.partial('partial_name');
 // or
-_.partial('partial_name', partial_data);
+_.template.partial('partial_name', partial_data);
 
 // Check if a partial exists
-_.partial.exists('partial_name');
+_.template.partial.exists('partial_name');
 
 // Remove a partial that was declared before
-_.partial.remove('partial_name');
+_.template.partial.remove('partial_name');
 
 ```
 

--- a/build/underscore-partials.min.js
+++ b/build/underscore-partials.min.js
@@ -1,1 +1,1 @@
-(function(){var n={},t=function(t,e){return n[t](e)};t.declare=function(t,e,i){n[t]=_.template(e,void 0,i)},t.exists=function(t){return _.isFunction(n[t])},t.remove=function(t){delete n[t]},_.mixin({partial:t})})();
+(function(t){var e=t._,n={},i=function(t,e){return n[t](e)};i.declare=function(t,i,o){n[t]=e.template(i,void 0,o)},i.exists=function(t){return e.isFunction(n[t])},i.remove=function(t){delete n[t]},e.template.partial=i})(this);

--- a/specs/specs.js
+++ b/specs/specs.js
@@ -1,47 +1,47 @@
 describe("Underscore partials", function() {
     it("can declare a new partial", function() {
         var partial = "hello";
-        _.partial.declare("hello", partial);
-        expect(_.partial("hello")).toBe("hello");
+        _.template.partial.declare("hello", partial);
+        expect(_.template.partial("hello")).toBe("hello");
     });
 
     it("can overwrite an existing partial", function() {
         var partial = "hello";
         var new_partial = "hello mom!";
-        _.partial.declare("hello", partial);
-        _.partial.declare("hello", new_partial);
-        expect(_.partial("hello")).toBe("hello mom!");
+        _.template.partial.declare("hello", partial);
+        _.template.partial.declare("hello", new_partial);
+        expect(_.template.partial("hello")).toBe("hello mom!");
     });
 
     it("can tell you if a partial exists", function(){
         var partial = "hello";
-        _.partial.declare("hello", partial);
-        expect(_.partial.exists("hello")).toBe(true);
+        _.template.partial.declare("hello", partial);
+        expect(_.template.partial.exists("hello")).toBe(true);
     });
 
     it("can tell you if a partial does not exist", function(){
-        expect(_.partial.exists("this_partial_does_not_exist")).toBe(false);
+        expect(_.template.partial.exists("this_partial_does_not_exist")).toBe(false);
     });
 
     it("can remove a partial", function(){
         var partial = "hello";
-        _.partial.declare("hello", partial);
-        expect(_.partial.exists("hello")).toBe(true);
+        _.template.partial.declare("hello", partial);
+        expect(_.template.partial.exists("hello")).toBe(true);
 
-        _.partial.remove("hello");
-        expect(_.partial.exists("hello")).toBe(false);
+        _.template.partial.remove("hello");
+        expect(_.template.partial.exists("hello")).toBe(false);
     });
 
     it("gives you the full power of Underscore templates in a partial", function(){
         var partial = "Hello <%= name %>";
-        _.partial.declare("hello", partial);
-        expect(_.partial("hello", {name: "bob"})).toBe("Hello bob");
+        _.template.partial.declare("hello", partial);
+        expect(_.template.partial("hello", {name: "bob"})).toBe("Hello bob");
     });
 
     it("let's you use a partial inside of a template", function(){
-        var template = "User rating: <%= _.partial('star_rating', {rating: 4}) %>";
+        var template = "User rating: <%= _.template.partial('star_rating', {rating: 4}) %>";
         var partial = "<%= rating %> stars (<% for(var i = 0; i < rating; i++) { %>*<% } %>)";
-        _.partial.declare('star_rating', partial);
+        _.template.partial.declare('star_rating', partial);
         template = _.template(template);
 
         expect(template()).toBe("User rating: 4 stars (****)");
@@ -61,28 +61,28 @@ describe("Underscore partials", function() {
 
         it("can declare a new partial", function() {
             var partial = "hello";
-            _.partial.declare("hello", partial, templateSettings1);
-            expect(_.partial("hello")).toBe("hello");
+            _.template.partial.declare("hello", partial, templateSettings1);
+            expect(_.template.partial("hello")).toBe("hello");
         });
 
         it("can overwrite an existing partial", function() {
             var partial1 = "hello1 <@= name @>!";
             var partial2 = "hello2 <#= name #>!";
-            _.partial.declare("hello", partial1, templateSettings1);
-            _.partial.declare("hello", partial2, templateSettings2);
-            expect(_.partial("hello", {name: "bob"})).toBe("hello2 bob!");
+            _.template.partial.declare("hello", partial1, templateSettings1);
+            _.template.partial.declare("hello", partial2, templateSettings2);
+            expect(_.template.partial("hello", {name: "bob"})).toBe("hello2 bob!");
         });
 
         it("gives you the full power of Underscore templates in a partial", function(){
             var partial = "Hello <@= name @>";
-            _.partial.declare("hello", partial, templateSettings1);
-            expect(_.partial("hello", {name: "bob"})).toBe("Hello bob");
+            _.template.partial.declare("hello", partial, templateSettings1);
+            expect(_.template.partial("hello", {name: "bob"})).toBe("Hello bob");
         });
 
         it("let's you use a partial inside of a template", function(){
             var partial = "<@= rating @> stars (<@ for(var i = 0; i < rating; i++) { @>*<@ } @>)";
-            var template = "User rating: <#= _.partial('star_rating', {rating: 4}) #>";
-            _.partial.declare('star_rating', partial, templateSettings1);
+            var template = "User rating: <#= _.template.partial('star_rating', {rating: 4}) #>";
+            _.template.partial.declare('star_rating', partial, templateSettings1);
             template = _.template(template, undefined, templateSettings2);
 
             expect(template()).toBe("User rating: 4 stars (****)");

--- a/underscore-partials.js
+++ b/underscore-partials.js
@@ -1,4 +1,6 @@
-(function() {
+(function(root) {
+    var _ = root._;
+
     /**
      * Allow underscore use of partials
      */
@@ -20,7 +22,6 @@
         delete partialCache[name];
     };
 
-    _.mixin({
-        partial: partial
-    });
-})();
+    // extend Underscore
+    _.template.partial = partial;
+})(this);


### PR DESCRIPTION
Move partials functionality to `_.template.partial` instead of overwriting Underscore's `_.partial` method.

This change breaks backwards-compatibility so I think that the version number must be bumped to 2.0.0.
